### PR TITLE
fix: use the github repo for fsnotify

### DIFF
--- a/rfsnotify.go
+++ b/rfsnotify.go
@@ -2,7 +2,7 @@
 package rfsnotify
 
 import (
-	"gopkg.in/fsnotify.v1"
+	"github.com/fsnotify/fsnotify"
 
 	"errors"
 	"os"


### PR DESCRIPTION
Using github.com/fsnotify/fsnotify instead of gopkg.in/fsnotify.v1 as the latter seems old and doesn't have event.Has().